### PR TITLE
Add data_dir flag to lightning example

### DIFF
--- a/pl_mnist.py
+++ b/pl_mnist.py
@@ -43,9 +43,10 @@ if __name__ == '__main__':
     parser.add_argument('--lr', type=float, default=1e-3)
     parser.add_argument('--batch_size', type=int, default=32)
     parser.add_argument('--max_epochs', type=int, default=10)
+    parser.add_argument('--data_dir', type=str, default=os.getcwd())
     args = parser.parse_args()
 
-    dataset = MNIST(os.getcwd(), download=True, transform=transforms.ToTensor())
+    dataset = MNIST(args.data_dir, download=True, transform=transforms.ToTensor())
     train_loader = DataLoader(dataset, batch_size=args.batch_size)
 
     # init model


### PR DESCRIPTION
This PR adds `--data_dir` as a flag to lightning script to allow for EZ use w/ datastores 🚀 . if not provided, it still uses `os.getcwd()` as before.